### PR TITLE
chore: upgrade to MPR 7 and Vaadin 24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-server</artifactId>
+            <artifactId>vaadin-server-mpr-jakarta</artifactId>
             <version>${vaadin8.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/org/vaadin/mprdemo/ApplicationConfig.java
+++ b/src/main/java/org/vaadin/mprdemo/ApplicationConfig.java
@@ -1,0 +1,12 @@
+package org.vaadin.mprdemo;
+
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.component.page.Push;
+import com.vaadin.mpr.core.LegacyUI;
+import com.vaadin.mpr.core.MprTheme;
+
+@Push
+@MprTheme("mytheme")
+@LegacyUI(OldUI.class)
+public class ApplicationConfig implements AppShellConfigurator {
+}

--- a/src/main/java/org/vaadin/mprdemo/MyUI.java
+++ b/src/main/java/org/vaadin/mprdemo/MyUI.java
@@ -1,6 +1,5 @@
 package org.vaadin.mprdemo;
 
-import com.vaadin.annotations.Push;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
@@ -12,20 +11,14 @@ import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.RouterLink;
-import com.vaadin.mpr.core.LegacyUI;
-import com.vaadin.mpr.core.MprTheme;
 import com.vaadin.server.VaadinSession;
 
-@Push
 @Route("")
-@MprTheme("mytheme")
 @CssImport("custom.css")
-@LegacyUI(OldUI.class)
-public class MyUI extends AppLayout implements RouterLayout, AppShellConfigurator {
+public class MyUI extends AppLayout implements RouterLayout {
 
 	private static final String VAADIN_THEMES = "/VAADIN/themes/";
 


### PR DESCRIPTION
Draft PR for vaadin/multiplatform-runtime-internal#675

`AppShellConfigurator` implementation has been moved to a new class to avoid creation of an instance of `MyUI` during bootstrap

DO NOT MERGE on mpr-6 branch
