### PR TITLE
chore: Removes the debug window workaround that produces errors

### DIFF
--- a/src/main/java/org/vaadin/mprdemo/MyUI.java
+++ b/src/main/java/org/vaadin/mprdemo/MyUI.java
@@ -67,12 +67,9 @@ public class MyUI extends AppLayout implements RouterLayout {
 
 	@Override
 	public void onAttach(AttachEvent event) {
-		if (event.getSession().getService().getDeploymentConfiguration().isProductionMode()) {
-			event.getUI().getPage().executeJs("window.vaadin.debug=false;");
-		}
 		if (VaadinSession.getCurrent().getService().getDeploymentConfiguration().isProductionMode()) {
 			Notification.show("Vaadin 8 runs in prod mode");
-		}		
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This was apparently used for very old versions of Vaadin and now just produces JS errors, this "debug" object is not used.