### PR TITLE
Enable frontend build logging for easier debugging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,11 @@
             <artifactId>vaadin-dev</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.17</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,0 +1,2 @@
+# Log frontend build tool output (pnpm, npm, vite) for easier debugging
+org.slf4j.simpleLogger.log.com.vaadin.flow.server.frontend=debug


### PR DESCRIPTION
## Summary
- Add `slf4j-simple` dependency to provide an SLF4J binding
- Configure `com.vaadin.flow.server.frontend` at DEBUG level via `simplelogger.properties`

## Why
When `pnpm install` fails during dev mode startup (`DevModeInitializer`), the exception only says "check pnpm command output" but the actual pnpm error (e.g., `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`) is logged at DEBUG/ERROR level through SLF4J. Without a configured SLF4J binding, this output is lost and debugging CI failures becomes very difficult.

## What changes
- `pom.xml`: Added `slf4j-simple:2.0.17` dependency
- `src/main/resources/simplelogger.properties`: Set `com.vaadin.flow.server.frontend` to DEBUG level